### PR TITLE
Add support for files containing leading comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
-module.exports = function transformer(file, api) {
+module.exports.default = function transformer(file, api) {
   const j = api.jscodeshift;
   const root = j(file.source);
+  const getFirstNode = () => root.find(j.Program).get("body", 0).node;
+
+  // Save the comments attached to the first node
+  const firstNode = getFirstNode();
+  const { comments } = firstNode;
 
   root
     .find(j.ImportDeclaration)
@@ -39,6 +44,12 @@ module.exports = function transformer(file, api) {
       )
     );
   });
+
+  // If the first node has been modified or deleted, reattach the comments
+  const firstNode2 = getFirstNode();
+  if (firstNode2 !== firstNode) {
+    firstNode2.comments = comments;
+  }
 
   return root.toSource();
 };


### PR DESCRIPTION
Currently a file subject to this codemod will have its leading comments (eg // @flow) deleted. This diff resolves that issue. https://github.com/facebook/jscodeshift/blob/master/recipes/retain-first-comment.md